### PR TITLE
feat: Claude AI Architect Accelerator partnership page (/claude-accelerator)

### DIFF
--- a/src/app/(fransunisoft)/claude-accelerator/claude-accelerator.module.css
+++ b/src/app/(fransunisoft)/claude-accelerator/claude-accelerator.module.css
@@ -1,0 +1,629 @@
+/* ── Page wrapper ── */
+.page {
+  font-family: "Roboto", sans-serif;
+  color: #2c3e50;
+  background: #fcfaff;
+}
+
+/* ── HERO ── */
+.hero {
+  background: linear-gradient(135deg, #0d519a 0%, #0a3d7a 60%, #1a2a4a 100%);
+  color: white;
+  padding: 5rem 1.5rem 4rem;
+  text-align: center;
+}
+
+.heroInner {
+  max-width: 780px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.partnerBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 107, 53, 0.18);
+  border: 1px solid rgba(255, 107, 53, 0.45);
+  color: #ffb499;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+}
+
+.badgeDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #FF6B35;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(1.3); }
+}
+
+.heroProgrammeBadge {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.heroTitle {
+  font-size: clamp(2.2rem, 6vw, 3.6rem);
+  font-weight: 900;
+  line-height: 1.08;
+  margin: 0;
+  color: white;
+}
+
+.heroAccent {
+  color: #22d3ee;
+}
+
+.heroSub {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: rgba(255, 255, 255, 0.78);
+  max-width: 600px;
+  margin: 0;
+}
+
+.cohortPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.cohortPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: white;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+}
+
+.cohortPill2 {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+}
+
+.liveDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #10b981;
+  animation: pulse 1.6s infinite;
+}
+
+.heroBtn {
+  display: inline-block;
+  background: #FF6B35;
+  color: white;
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.9rem 2.4rem;
+  border-radius: 0.6rem;
+  text-decoration: none;
+  transition: background 0.2s, transform 0.15s;
+  margin-top: 0.5rem;
+}
+
+.heroBtn:hover {
+  background: #e05520;
+  transform: translateY(-2px);
+}
+
+.heroNote {
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.45);
+  margin: 0;
+}
+
+/* ── STATS BAR ── */
+.statsBar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0;
+  background: #0d519a;
+  padding: 1.6rem 1rem;
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem 2.5rem;
+  border-right: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.statItem:last-child {
+  border-right: none;
+}
+
+.statVal {
+  font-size: 1.6rem;
+  font-weight: 900;
+  color: white;
+  line-height: 1;
+}
+
+.statLabel {
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-top: 0.3rem;
+}
+
+/* ── SHARED SECTION ── */
+.section {
+  padding: 5rem 1.5rem;
+}
+
+.sectionInner {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.sectionLabel {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #0d519a;
+  text-align: center;
+  margin-bottom: 0.75rem;
+}
+
+.sectionTitle {
+  font-size: clamp(1.7rem, 4vw, 2.4rem);
+  font-weight: 800;
+  text-align: center;
+  color: #2c3e50;
+  margin: 0 0 1rem;
+  line-height: 1.2;
+}
+
+.sectionSub {
+  text-align: center;
+  color: #7c8084;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  max-width: 620px;
+  margin: 0 auto 3rem;
+}
+
+.accent {
+  color: #0d519a;
+}
+
+/* ── LEVELS ── */
+.levelsGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.levelCard {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.875rem;
+  padding: 1.4rem 1.6rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+
+.levelNum {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: white;
+  font-weight: 900;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.levelContent {
+  flex: 1;
+}
+
+.levelTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #2c3e50;
+  margin: 0 0 0.2rem;
+}
+
+.levelDuration {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #0d519a;
+  background: rgba(13, 81, 154, 0.1);
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  display: inline-block;
+  margin-bottom: 0.6rem;
+}
+
+.levelDesc {
+  font-size: 0.88rem;
+  color: #7c8084;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.pathwayCard {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  background: #fff8f5;
+  border: 2px solid #FF6B35;
+  border-radius: 0.875rem;
+  padding: 1.4rem 1.6rem;
+}
+
+.starIcon {
+  font-size: 1.5rem;
+  color: #FF6B35;
+  flex-shrink: 0;
+  line-height: 1;
+  margin-top: 0.1rem;
+}
+
+.pathwayTitle {
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #FF6B35;
+  margin-bottom: 0.4rem;
+}
+
+.pathwayDesc {
+  font-size: 0.88rem;
+  color: #7c8084;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ── OUTCOMES ── */
+.outcomesSection {
+  background: #f0f6ff;
+  padding: 5rem 1.5rem;
+}
+
+.outcomesGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.outcomeItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: white;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  font-size: 0.9rem;
+  color: #2c3e50;
+  font-weight: 500;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.checkIcon {
+  color: #0d519a;
+  font-weight: 900;
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+/* ── WHY ── */
+.whyGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+  margin-top: 2.5rem;
+}
+
+.whyCard {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.05);
+}
+
+.whyIcon {
+  font-size: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.whyTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #2c3e50;
+  margin: 0 0 0.6rem;
+}
+
+.whyDesc {
+  font-size: 0.88rem;
+  color: #7c8084;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ── PRICING ── */
+.pricingSection {
+  background: #0d519a;
+  padding: 5rem 1.5rem;
+}
+
+.pricingSection .sectionLabel {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.pricingSection .sectionTitle {
+  color: white;
+}
+
+.pricingSection .sectionSub {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.pricingGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.1rem;
+  margin-top: 2.5rem;
+}
+
+.pricingCard {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 1rem;
+  padding: 1.6rem 1.5rem;
+  color: white;
+  position: relative;
+  transition: transform 0.2s;
+}
+
+.pricingCard:hover {
+  transform: translateY(-3px);
+}
+
+.pricingCardHL {
+  background: #FF6B35;
+  border-color: #FF6B35;
+}
+
+.popularBadge {
+  position: absolute;
+  top: -0.6rem;
+  right: 1rem;
+  background: white;
+  color: #FF6B35;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+}
+
+.pricingAmount {
+  font-size: 1.9rem;
+  font-weight: 900;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+}
+
+.pricingName {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.pricingNote {
+  font-size: 0.78rem;
+  opacity: 0.75;
+}
+
+.pricingDisclaimer {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.8rem;
+  margin-top: 1.75rem;
+  line-height: 1.6;
+}
+
+/* ── COHORT ── */
+.cohortGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.cohortCard {
+  background: white;
+  border: 2px solid #e2e8f0;
+  border-radius: 1.1rem;
+  padding: 2rem 1.75rem;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.cohortNum {
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #0d519a;
+  margin-bottom: 0.75rem;
+}
+
+.cohortDates {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #2c3e50;
+  margin-bottom: 0.6rem;
+  line-height: 1.3;
+}
+
+.cohortDetail {
+  font-size: 0.82rem;
+  color: #7c8084;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.cohortBtn {
+  display: inline-block;
+  background: #0d519a;
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.7rem 1.6rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+
+.cohortBtn:hover {
+  background: #0a3d7a;
+}
+
+/* ── FINAL CTA ── */
+.ctaSection {
+  background: linear-gradient(135deg, #1a0a2e 0%, #0d519a 100%);
+  padding: 5rem 1.5rem;
+  text-align: center;
+}
+
+.ctaInner {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.ctaTitle {
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 900;
+  color: white;
+  line-height: 1.15;
+  margin: 0 0 1.25rem;
+}
+
+.ctaSub {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1rem;
+  line-height: 1.75;
+  margin: 0 0 2rem;
+}
+
+.ctaBtn {
+  display: inline-block;
+  background: #FF6B35;
+  color: white;
+  font-size: 1.05rem;
+  font-weight: 800;
+  padding: 1rem 2.8rem;
+  border-radius: 0.7rem;
+  text-decoration: none;
+  transition: background 0.2s, transform 0.15s;
+}
+
+.ctaBtn:hover {
+  background: #e05520;
+  transform: translateY(-2px);
+}
+
+.ctaContact {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.82rem;
+  margin-top: 1.5rem;
+}
+
+.ctaEmail {
+  color: #22d3ee;
+  text-decoration: underline;
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 768px) {
+  .statsBar {
+    gap: 0.5rem;
+    padding: 1.25rem 0.5rem;
+  }
+
+  .statItem {
+    padding: 0.5rem 1.2rem;
+    border-right: none;
+    border-bottom: 1px solid rgba(255,255,255,0.12);
+  }
+
+  .statItem:last-child {
+    border-bottom: none;
+  }
+
+  .outcomesGrid,
+  .whyGrid,
+  .pricingGrid,
+  .cohortGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .levelCard,
+  .pathwayCard {
+    flex-direction: row;
+  }
+
+  .section,
+  .outcomesSection,
+  .pricingSection,
+  .ctaSection {
+    padding: 3.5rem 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .heroTitle {
+    font-size: 2rem;
+  }
+
+  .cohortPills {
+    flex-direction: column;
+    align-items: center;
+  }
+}

--- a/src/app/(fransunisoft)/claude-accelerator/page.jsx
+++ b/src/app/(fransunisoft)/claude-accelerator/page.jsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect } from "react";
+import AOS from "aos";
+import "aos/dist/aos.css";
+import styles from "./claude-accelerator.module.css";
+
+const GOOGLE_FORM_URL = "https://bit.ly/ClaudeAIArchitectAcceleratorNG";
+
+const OUTCOMES = [
+  "Claude Certified Associate – Fundamentals (CCA-F) credential",
+  "Hands-on Claude API, agents, MCP & RAG skills",
+  "A portfolio of real, deployed AI projects",
+  "Access to the Biz Boosters associate engineer network",
+  "Project placement opportunities via Fransunisoft",
+  "Confidence to build & sell AI — from zero",
+];
+
+const LEVELS = [
+  {
+    num: "1",
+    title: "AI Foundations",
+    duration: "4 weeks · No coding",
+    desc: "For anyone. Understand AI & Claude, prompt writing, and real business use cases. Start using AI confidently.",
+    color: "#0D519A",
+  },
+  {
+    num: "2",
+    title: "Business AI Practitioner",
+    duration: "4 weeks · No coding",
+    desc: "Apply AI to your work — advanced prompting, workflow design, AI strategy. Prepares for certification.",
+    color: "#0D519A",
+  },
+  {
+    num: "3",
+    title: "Claude Certified Architect",
+    duration: "6 weeks · Coding taught",
+    desc: "Full CCA-F exam prep. Claude API, agents, MCP, RAG — hands-on. Exam fee included via Biz Boosters.",
+    color: "#FF6B35",
+  },
+];
+
+const PRICING = [
+  { id: "1", name: "Registration + Materials", amount: "₦150,000", note: "Self-paced · Full programme access" },
+  { id: "2", name: "Materials + Tutorials", amount: "₦200,000", note: "Live tutorial sessions included" },
+  { id: "3", name: "Materials + Certification Track", amount: "₦350,000", note: "CCA-F exam preparation" },
+  { id: "4", name: "Full Package — Everything", amount: "₦500,000", note: "Most complete · Exam fee included", highlight: true },
+];
+
+const WHY_ITEMS = [
+  {
+    icon: "🤝",
+    title: "Official Anthropic Claude Partner",
+    desc: "Biz Boosters is an authorised Anthropic Claude Partner. The CCA-F exam is partner-gated — enrolling with us is your direct route to it.",
+  },
+  {
+    icon: "🇳🇬",
+    title: "Built for Nigerian Professionals",
+    desc: "Weekend cohorts, NGN pricing with instalment plans, and a community led by Fransunisoft — Africa's talent & innovation studio.",
+  },
+  {
+    icon: "🏗️",
+    title: "Engineers Who Deploy Claude Daily",
+    desc: "Sessions are taught by practitioners who build real AI products — TalkWeb, GrantsCopilot, TaxMasta — not just online instructors.",
+  },
+  {
+    icon: "📜",
+    title: "Globally Recognised Certification",
+    desc: "The Anthropic CCA-F credential is the only official Claude AI certification. It signals real technical capability to employers worldwide.",
+  },
+];
+
+export default function ClaudeAcceleratorPage() {
+  useEffect(() => {
+    setTimeout(() => {
+      AOS.init({ duration: 900, once: true });
+    }, 100);
+  }, []);
+
+  return (
+    <main className={styles.page}>
+
+      {/* ── HERO ── */}
+      <section className={styles.hero}>
+        <div className={styles.heroInner} data-aos="fade-up">
+          <div className={styles.partnerBadge}>
+            <span className={styles.badgeDot} />
+            Official Anthropic Claude Partner
+          </div>
+
+          <div className={styles.heroProgrammeBadge}>AI ARCHITECT ACCELERATOR</div>
+
+          <h1 className={styles.heroTitle}>
+            Claude AI Architect<br />
+            <span className={styles.heroAccent}>Accelerator</span>
+          </h1>
+
+          <p className={styles.heroSub}>
+            A career &amp; business transformation programme — from zero technical skills to a
+            Certified Claude AI Architect. Delivered in Nigeria by{" "}
+            <strong>Fransunisoft</strong> in partnership with{" "}
+            <strong>Biz Boosters (UK)</strong>.
+          </p>
+
+          <div className={styles.cohortPills}>
+            <span className={styles.cohortPill}>
+              <span className={styles.liveDot} />
+              Cohort 1: 28 Jul – 3 Oct 2026
+            </span>
+            <span className={styles.cohortPill2}>
+              Cohort 2: 3 Nov 2026 – 9 Jan 2027
+            </span>
+          </div>
+
+          <a
+            href={GOOGLE_FORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.heroBtn}
+          >
+            Register Your Interest →
+          </a>
+
+          <p className={styles.heroNote}>
+            No payment now — register interest and we&apos;ll confirm your spot &amp; pricing details.
+          </p>
+        </div>
+      </section>
+
+      {/* ── STATS BAR ── */}
+      <section className={styles.statsBar} data-aos="fade-up">
+        {[
+          { val: "14 Weeks", label: "Full Pathway" },
+          { val: "₦150k", label: "Starting from" },
+          { val: "Live", label: "Weekend Sessions" },
+          { val: "CCA-F", label: "Certification" },
+        ].map((s) => (
+          <div key={s.label} className={styles.statItem}>
+            <span className={styles.statVal}>{s.val}</span>
+            <span className={styles.statLabel}>{s.label}</span>
+          </div>
+        ))}
+      </section>
+
+      {/* ── THE PATHWAY ── */}
+      <section className={styles.section}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionLabel} data-aos="fade-up">THE PATHWAY</div>
+          <h2 className={styles.sectionTitle} data-aos="fade-up">
+            From zero technical skills to a{" "}
+            <span className={styles.accent}>Certified Claude AI Architect</span>
+          </h2>
+          <p className={styles.sectionSub} data-aos="fade-up">
+            Three progressive levels. Start anywhere — or take the Full Pathway and we&apos;ll take you all the way.
+          </p>
+
+          <div className={styles.levelsGrid}>
+            {LEVELS.map((lv, i) => (
+              <div key={lv.num} className={styles.levelCard} data-aos="fade-up" data-aos-delay={i * 100}>
+                <div className={styles.levelNum} style={{ background: lv.color }}>{lv.num}</div>
+                <div className={styles.levelContent}>
+                  <h3 className={styles.levelTitle}>{lv.title}</h3>
+                  <span className={styles.levelDuration}>{lv.duration}</span>
+                  <p className={styles.levelDesc}>{lv.desc}</p>
+                </div>
+              </div>
+            ))}
+            {/* Full Pathway */}
+            <div className={styles.pathwayCard} data-aos="fade-up" data-aos-delay={300}>
+              <span className={styles.starIcon}>★</span>
+              <div>
+                <div className={styles.pathwayTitle}>Full Pathway — all 3 levels</div>
+                <p className={styles.pathwayDesc}>
+                  The complete journey, zero to certified. Recommended if you&apos;re starting fresh and want the credential.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── WHAT YOU LEAVE WITH ── */}
+      <section className={styles.outcomesSection}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionLabel} data-aos="fade-up">WHAT YOU LEAVE WITH</div>
+          <h2 className={styles.sectionTitle} data-aos="fade-up">Programme Outcomes</h2>
+          <div className={styles.outcomesGrid}>
+            {OUTCOMES.map((o, i) => (
+              <div key={i} className={styles.outcomeItem} data-aos="fade-up" data-aos-delay={i * 60}>
+                <span className={styles.checkIcon}>✓</span>
+                <span>{o}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── WHY LEARN WITH US ── */}
+      <section className={styles.section}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionLabel} data-aos="fade-up">WHY LEARN WITH US</div>
+          <h2 className={styles.sectionTitle} data-aos="fade-up">Built for Real Outcomes</h2>
+          <div className={styles.whyGrid}>
+            {WHY_ITEMS.map((item, i) => (
+              <div key={i} className={styles.whyCard} data-aos="fade-up" data-aos-delay={i * 80}>
+                <div className={styles.whyIcon}>{item.icon}</div>
+                <h3 className={styles.whyTitle}>{item.title}</h3>
+                <p className={styles.whyDesc}>{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── NIGERIA PRICING ── */}
+      <section className={styles.pricingSection}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionLabel} data-aos="fade-up">NIGERIA PRICING</div>
+          <h2 className={styles.sectionTitle} data-aos="fade-up">Pick Your Package</h2>
+          <p className={styles.sectionSub} data-aos="fade-up">
+            Instalment plans available. Employer invoice on request.
+          </p>
+          <div className={styles.pricingGrid}>
+            {PRICING.map((p, i) => (
+              <div
+                key={p.id}
+                className={`${styles.pricingCard} ${p.highlight ? styles.pricingCardHL : ""}`}
+                data-aos="fade-up"
+                data-aos-delay={i * 80}
+              >
+                {p.highlight && <div className={styles.popularBadge}>Most Complete</div>}
+                <div className={styles.pricingAmount}>{p.amount}</div>
+                <div className={styles.pricingName}>{p.name}</div>
+                <div className={styles.pricingNote}>{p.note}</div>
+              </div>
+            ))}
+          </div>
+          <p className={styles.pricingDisclaimer} data-aos="fade-up">
+            UK diaspora rate: £249. Early-bird discount (25% off) for the first 20 registrations.
+            All prices subject to confirmation — register interest first.
+          </p>
+        </div>
+      </section>
+
+      {/* ── COHORT DATES ── */}
+      <section className={styles.section}>
+        <div className={styles.sectionInner}>
+          <div className={styles.sectionLabel} data-aos="fade-up">COHORT SCHEDULE</div>
+          <h2 className={styles.sectionTitle} data-aos="fade-up">Upcoming Cohorts</h2>
+          <div className={styles.cohortGrid}>
+            <div className={styles.cohortCard} data-aos="fade-left">
+              <div className={styles.cohortNum}>Cohort 1</div>
+              <div className={styles.cohortDates}>28 July – 3 October 2026</div>
+              <div className={styles.cohortDetail}>Weekend sessions · Live on Zoom · WhatsApp community</div>
+              <a href={GOOGLE_FORM_URL} target="_blank" rel="noopener noreferrer" className={styles.cohortBtn}>
+                Register Interest →
+              </a>
+            </div>
+            <div className={styles.cohortCard} data-aos="fade-right">
+              <div className={styles.cohortNum}>Cohort 2</div>
+              <div className={styles.cohortDates}>3 November 2026 – 9 January 2027</div>
+              <div className={styles.cohortDetail}>Weekend sessions · Live on Zoom · WhatsApp community</div>
+              <a href={GOOGLE_FORM_URL} target="_blank" rel="noopener noreferrer" className={styles.cohortBtn}>
+                Join Waitlist →
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FINAL CTA ── */}
+      <section className={styles.ctaSection} data-aos="fade-up">
+        <div className={styles.ctaInner}>
+          <div className={styles.partnerBadge} style={{ justifyContent: "center", marginBottom: "1.5rem" }}>
+            <span className={styles.badgeDot} />
+            Powered by Biz Boosters · Official Anthropic Claude Partner
+          </div>
+          <h2 className={styles.ctaTitle}>
+            Be among the first Certified<br />
+            Claude AI Architects in Nigeria
+          </h2>
+          <p className={styles.ctaSub}>
+            Places are limited. Register your interest now — no payment required at this stage.
+            Fransunisoft will confirm your spot and share full details.
+          </p>
+          <a
+            href={GOOGLE_FORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.ctaBtn}
+          >
+            Register Your Interest Now →
+          </a>
+          <p className={styles.ctaContact}>
+            Questions? Contact us at{" "}
+            <a href="mailto:hello@fransunisoft.com" className={styles.ctaEmail}>
+              hello@fransunisoft.com
+            </a>
+          </p>
+        </div>
+      </section>
+
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new page at `/claude-accelerator` for the **Biz Boosters × Fransunisoft** Nigeria distribution partnership
- Content replicates the [Biz Boosters Accelerator](https://www.bizboosters.co.uk/accelerator) programme with Nigerian framing, NGN pricing, and Fransunisoft branding
- All CTAs (Register Your Interest) link to the Google Form: **https://bit.ly/ClaudeAIArchitectAcceleratorNG**

## What's included on the page

- Hero with live cohort date pill, Anthropic Claude Partner badge, and register CTA
- Three-level pathway cards (AI Foundations → Business AI Practitioner → Claude Certified Architect)
- Programme outcomes grid (CCA-F credential, portfolio, associate engineer network)
- "Why learn with us" section highlighting Anthropic partnership, Nigeria focus, and live delivery
- Nigeria NGN pricing grid (₦150,000 – ₦500,000) with instalment plan note
- Cohort schedule cards for Cohort 1 (28 Jul – 3 Oct 2026) and Cohort 2 (3 Nov 2026 – 9 Jan 2027)
- Final CTA section linking to Google Form

## Files changed

| File | Change |
|---|---|
| `src/app/(fransunisoft)/claude-accelerator/page.jsx` | New — page component |
| `src/app/(fransunisoft)/claude-accelerator/claude-accelerator.module.css` | New — page styles |

## Test plan

- [ ] `npm run dev` → visit `/claude-accelerator`
- [ ] Verify "Register Your Interest" buttons open `https://bit.ly/ClaudeAIArchitectAcceleratorNG` in a new tab
- [ ] Check mobile layout (outcomesGrid, pricingGrid, cohortGrid stack to 1 column)
- [ ] Confirm Navbar and Footer are present (auto-included via `(fransunisoft)/layout.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)